### PR TITLE
Bump macos x64 runners due to deprecation

### DIFF
--- a/.github/workflows/ci-appimage.yml
+++ b/.github/workflows/ci-appimage.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -38,7 +38,7 @@ jobs:
         ln -s /usr/bin/gcc-10 $HOME/.local/bin/gcc
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -23,15 +23,16 @@ jobs:
     name: CI on Linux
 
     runs-on: ubuntu-20.04
+    # Oldest supported so releases can run on older distros
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Install FSF toolchain
-      uses: alire-project/alr-install@v1
+      uses: alire-project/alr-install@v2
       with:
         crates: gnat_native gprbuild
         prefix: alire_prefix
@@ -40,7 +41,7 @@ jobs:
       uses: mosteo-actions/gnat-toolchain-arch-checker@v1
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -11,9 +11,6 @@ on:
     types: [published]
   workflow_dispatch:
 
-env:
-  ARCH: x86_64
-
 jobs:
 
   build:
@@ -22,39 +19,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-12, macos-14]
+        os:
+          - macos-13     # x64
+          - macos-latest # arm64
 
     runs-on: ${{ matrix.os }}
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
-    - name: Install FSF toolchain (x86_64)
-      if: ${{ matrix.os != 'macos-14' }}
-      uses: alire-project/alr-install@v1
+    - name: Install FSF toolchain
+      uses: alire-project/alr-install@v2
       with:
         crates: gnat_native gprbuild
         prefix: alire_prefix
-
-    - name: Install FSF toolchain (AArch64)
-      if: ${{ matrix.os == 'macos-14' }}
-      run: |
-        curl -L -O https://github.com/alire-project/alire/releases/download/nightly/alr-nightly-bin-aarch64-macos.zip
-        unzip alr-nightly-bin-aarch64-macos.zip bin/alr
-        bin/alr index --reset-community
-        bin/alr install gnat_native gprbuild --prefix alire_prefix
-        echo $PWD/bin >> $GITHUB_PATH
-        echo $PWD/alire_prefix/bin >> $GITHUB_PATH
-        echo "ARCH=aarch64" >> $GITHUB_ENV
 
     - name: Check toolchain architecture
       uses: mosteo-actions/gnat-toolchain-arch-checker@v1
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 
@@ -75,7 +62,7 @@ jobs:
     - name: Upload binaries
       uses: actions/upload-artifact@v4
       with:
-        name: alr-bin-${{ env.ARCH }}-macos.zip
+        name: alr-bin-${{ runner.arch }}-macos.zip
         path: |
           bin/alr
           LICENSE.txt
@@ -84,7 +71,7 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@v4
       with:
-        name: testsuite-log-macos.zip
+        name: testsuite-log-macos-${{ runner.arch }}.zip
         path: testsuite/out
 
     # Release steps start here. These only run during a release creation.
@@ -105,6 +92,17 @@ jobs:
       if: github.event_name == 'release'
       run: zip alr-bin-macos.zip bin/alr LICENSE.txt
 
+    - name: Select arch name
+      id: get_arch
+      if: github.event_name == 'release'
+      shell: bash
+      run: |
+        case ${{ runner.arch }} in
+          X64)   echo "arch=x86_64"  >> $GITHUB_OUTPUT ;;
+          ARM64) echo "arch=aarch64" >> $GITHUB_OUTPUT ;;
+          *)     echo "Unknown architecture, failing..." && exit 1 ;;
+        esac
+
     - name: Upload release assets
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1
@@ -113,5 +111,5 @@ jobs:
       with:
         upload_url: ${{ steps.get_release.outputs.upload_url }}
         asset_path: alr-bin-macos.zip
-        asset_name: alr-${{ steps.get_version.outputs.version-without-v }}-bin-${{ env.ARCH }}-macos.zip
+        asset_name: alr-${{ steps.get_version.outputs.version-without-v }}-bin-${{ steps.get_arch.outputs.arch }}-macos.zip
         asset_content_type: application/zip

--- a/.github/workflows/ci-toolchain.yml
+++ b/.github/workflows/ci-toolchain.yml
@@ -26,21 +26,62 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-12
+          - macos-13
+          - macos-latest
+          - ubuntu-22.04
           - ubuntu-latest
           - windows-latest
         gcc_version: [10, 11, 12, 13, 14]
 
+        exclude:
+          # Some combos are not supported due to missing pieces in the toolchain
+
+          # Linking troubles on macos-13 for those gcc versions
+          - os: macos-13
+            gcc_version: 10
+          - os: macos-13
+            gcc_version: 11
+          - os: macos-13
+            gcc_version: 12
+          - os: macos-13
+            gcc_version: 13
+
+          # No builds of gcc-10, -11, -12 that work on arm64
+          - os: macos-latest
+            gcc_version: 10
+          - os: macos-latest
+            gcc_version: 11
+          - os: macos-latest
+            gcc_version: 12
+
+          # gcc-10 and -11 do not work on LTS 24.04 anymore
+          - os: ubuntu-latest
+            gcc_version: 10
+          - os: ubuntu-latest
+            gcc_version: 11
+
+          # exclude all ubuntu-22.04 because we are only interested in two
+          # older tests that are explicitly included next
+          - os: ubuntu-22.04
+
+        include:
+          # Only test gcc-10 and -11 on ubuntu-22.04 (to maintain testing
+          # back-compatibility, as those were being tested before)
+          - os: ubuntu-22.04
+            gcc_version: 10
+          - os: ubuntu-22.04
+            gcc_version: 11
+
     steps:
     - name: Check out
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     # Use a stock alr to make the latest toolchain available
 
     - name: Install FSF toolchain
-      uses: alire-project/alr-install@v1
+      uses: alire-project/alr-install@v2
       with:
         crates: gnat_native^${{matrix.gcc_version}} gprbuild
 
@@ -90,7 +131,7 @@ jobs:
     # alr in the ./bin/alr location.
 
     - name: Install Python 3.x # required by testsuite
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci-unsupported.yml
+++ b/.github/workflows/ci-unsupported.yml
@@ -20,17 +20,17 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Install FSF toolchain
-      uses: alire-project/alr-install@v1
+      uses: alire-project/alr-install@v2
       with:
         crates: gnat_native gprbuild
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -27,12 +27,12 @@ jobs:
 
     steps:
     - name: Check out repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Install FSF toolchain
-      uses: alire-project/alr-install@v1
+      uses: alire-project/alr-install@v2
       with:
         crates: gnat_native gprbuild
         prefix: alire_prefix
@@ -56,7 +56,7 @@ jobs:
       run: ${{env.PACMAN}} -S tar
 
     - name: Install Python 3.x (required for the testsuite)
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,9 +21,9 @@ jobs:
       fail-fast: false # Attempt to generate as many of them as possible
       matrix:
         os:
-          - macos-12
-          - macos-14
-          - ubuntu-20.04
+          - macos-13     # x64
+          - macos-14     # arm64
+          - ubuntu-20.04 # oldest supported to be able to run on those
           - windows-latest
 
     steps:


### PR DESCRIPTION
And generally all actions using old versions